### PR TITLE
Detached Entities

### DIFF
--- a/src/Detached.js
+++ b/src/Detached.js
@@ -1,0 +1,3 @@
+import { TagComponent } from "./TagComponent";
+
+export class Detached extends TagComponent {}

--- a/src/Query.js
+++ b/src/Query.js
@@ -1,5 +1,6 @@
 import EventDispatcher from "./EventDispatcher.js";
 import { queryKey } from "./Utils.js";
+import { Detached } from "./Detached";
 
 export default class Query {
   /**
@@ -9,13 +10,27 @@ export default class Query {
     this.Components = [];
     this.NotComponents = [];
 
+    var addNotDetached = true;
+
     Components.forEach(component => {
       if (typeof component === "object") {
         this.NotComponents.push(component.Component);
+
+        if (component.Component === Detached) {
+          addNotDetached = false;
+        }
       } else {
         this.Components.push(component);
+
+        if (component === Detached) {
+          addNotDetached = false;
+        }
       }
     });
+
+    if (addNotDetached) {
+      this.NotComponents.push(Detached);
+    }
 
     if (this.Components.length === 0) {
       throw new Error("Can't create a query without components");

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ export { System, Not } from "./System.js";
 export { Component } from "./Component.js";
 export { SystemStateComponent } from "./SystemStateComponent.js";
 export { TagComponent } from "./TagComponent.js";
+export { Detached } from "./Detached.js";
 export { createComponentClass } from "./CreateComponentClass.js";
 export { createType } from "./CreateType.js";
 export { Types } from "./StandardTypes.js";


### PR DESCRIPTION
Detached entities are not processed by queries unless explicitly configured. Detached entities can be used for pending entities while loading, prefabs, and deactivating entities without removing them.

To create a detached entity, add the `Detached` component. That entity will then be ignored by all queries by default. If you want a query to match detached entities you can add the `Detached` component to the query's components array.

Use Cases:
1. Loading Entities: If you are writing a system that loads resources such as an image or model and you don't want the entity to be processed by other systems until it finishes loading, you can create a detached entity. The loading systems will then process the detached entities and remove the detached component once all dependencies have been resolved.

2. Prefabs: If you want to use an entity as a prefab and clone it to make copies, or use it as the base object for an Object Pool, you probably don't want the prefab entity to be processed.

3. Deactivating Entities: Detaching an entity instead of removing it from the world may be desirable. For example in Mozilla Spoke, objects are added to an undo stack. An entity could be deactivated and then added to the undo stack so that it was not processed by systems. Culling systems are another example where you may want to detach an object based on distance.

Alternatives:

The detached entity feature is implemented by adding a default `Not(Detached)` component to each query. You may want additional filters that act in the same way. For example turning off and on entities based on what zone of a world you are in. Perhaps there's a way to create multiple tag components that are registered as default items in each query's components array. So `world.querySettings.defaultComponents.add(Not(Detached))` or something like it would let you register multiple default components.