### PR TITLE
typescript: parametrize World and System over Entity

### DIFF
--- a/src/System.d.ts
+++ b/src/System.d.ts
@@ -21,7 +21,7 @@ export interface SystemQueries {
 /**
  * A system that manipulates entities in the world.
  */
-export abstract class System {
+export abstract class System<EntityType extends Entity = Entity> {
   /**
    * Defines what Components the System will query for.
    * This needs to be user defined.
@@ -30,7 +30,7 @@ export abstract class System {
 
   static isSystem: true;
 
-  constructor(world: World, attributes?: Attributes);
+  constructor(world: World<EntityType>, attributes?: Attributes);
 
   /**
    * The results of the queries.
@@ -38,14 +38,14 @@ export abstract class System {
    */
   queries: {
     [queryName: string]: {
-      results: Entity[],
-      added?: Entity[],
-      removed?: Entity[],
-      changed?: Entity[],
+      results: EntityType[],
+      added?: EntityType[],
+      removed?: EntityType[],
+      changed?: EntityType[],
     }
   }
 
-  world: World;
+  world: World<EntityType>;
 
   /**
    * Whether the system will execute during the world tick.

--- a/src/World.d.ts
+++ b/src/World.d.ts
@@ -11,7 +11,8 @@ export interface WorldOptions {
 /**
  * The World is the root of the ECS.
  */
-export class World {
+export class World<EntityType extends Entity = Entity> {
+
   /**
    * Whether the world tick should execute.
    */
@@ -28,7 +29,7 @@ export class World {
    */
   registerComponent<C extends Component<any>>(Component: ComponentConstructor<C>, objectPool?: ObjectPool<C> | false): this;
 
-/**
+  /**
    * Evluate whether a component has been registered to this world or not.
    * @param Component Type of component to to evaluate
    */
@@ -68,7 +69,7 @@ export class World {
    * Resume execution of this world.
    */
   play(): void
- 
+
   /**
    * Stop execution of this world.
    */
@@ -77,5 +78,6 @@ export class World {
   /**
    * Create a new entity
    */
-  createEntity(name?: string): Entity
+  createEntity(name?: string): EntityType
+
 }


### PR DESCRIPTION
Hi,

This is a super simple PR introducing:
* `<Entity>` parametrization in the declaration of `World`
* `<Entity>` parametrization is the declaration of the class `System`.

## Why?

When creating a custom entity, all typings are lost (in favor of the base `Entity` class) in `createEntity` and inside inherited systems. It can make the framework a bit unpleasant to use, either because you need to cast first to `unknown`, or because you need to create an intermediate system class.