### PR TITLE
Fix entity not calling `dispose` on components when removed

### DIFF
--- a/src/EntityManager.js
+++ b/src/EntityManager.js
@@ -216,7 +216,6 @@ export class EntityManager {
         this.entitiesToRemove.push(entity);
       }
     }
-
   }
 
   _releaseEntity(entity, index) {

--- a/src/EntityManager.js
+++ b/src/EntityManager.js
@@ -204,6 +204,7 @@ export class EntityManager {
     if (!~index) throw new Error("Tried to remove entity not in list");
 
     entity.alive = false;
+    this.entityRemoveAllComponents(entity, immediately);
 
     if (entity.numStateComponents === 0) {
       // Remove from entity list
@@ -216,7 +217,6 @@ export class EntityManager {
       }
     }
 
-    this.entityRemoveAllComponents(entity, immediately);
   }
 
   _releaseEntity(entity, index) {

--- a/test/unit/entitymanager.test.js
+++ b/test/unit/entitymanager.test.js
@@ -1,5 +1,5 @@
 import test from "ava";
-import { World } from "../../src";
+import { Component, World } from "../../src";
 
 test("entity id", (t) => {
   var world = new World();
@@ -42,4 +42,41 @@ test("deferred entity remove", (t) => {
 
   t.is(world.entityManager.count(), 0);
   t.is(world.entityManager.entitiesToRemove.length, 0);
+});
+
+test("remove entity clears and reset components first ", (t) => {
+  class MyComponent extends Component {
+    constructor() {
+      super();
+      this.isReset = false;
+    }
+    dispose() {
+      this.isReset = true;
+      super.dispose();
+    }
+  }
+  const world = new World();
+  world.registerComponent(MyComponent, false);
+
+  let entity = world.createEntity();
+  entity.addComponent(MyComponent);
+
+  let component = entity.getComponent(MyComponent);
+  t.is(component.isReset, false);
+
+  // Deletes component immeditatly.
+  entity.remove(true);
+  t.is(component.isReset, true);
+
+  // Deletes component is a deferred manner.
+
+  entity = world.createEntity();
+  entity.addComponent(MyComponent);
+  component = entity.getComponent(MyComponent);
+  t.is(component.isReset, false);
+
+  entity.remove();
+  world.entityManager.processDeferredRemoval();
+  t.is(component.isReset, true);
+
 });

--- a/test/unit/entitymanager.test.js
+++ b/test/unit/entitymanager.test.js
@@ -78,5 +78,4 @@ test("remove entity clears and reset components first ", (t) => {
   entity.remove();
   world.entityManager.processDeferredRemoval();
   t.is(component.isReset, true);
-
 });


### PR DESCRIPTION
When entity are destroyed, either by calling `removeAllEntities` or `Entity.remove()`, the component don't get disposed. This is because `removeEntity()` is called first, clearing the components list whem the pool calls `entity.reset()`.