### PR TITLE
Add .js extensions to imports

### DIFF
--- a/src/SystemStateComponent.js
+++ b/src/SystemStateComponent.js
@@ -1,4 +1,4 @@
-import { Component } from "./Component";
+import { Component } from "./Component.js";
 
 export class SystemStateComponent extends Component {}
 

--- a/src/TagComponent.js
+++ b/src/TagComponent.js
@@ -1,4 +1,4 @@
-import { Component } from "./Component";
+import { Component } from "./Component.js";
 
 export class TagComponent extends Component {
   constructor() {


### PR DESCRIPTION
When loading the library from unpkg, this isn't a problem because it knows how to serve the files [even without extensions](https://unpkg.com/ecsy@0.4.1/src/Component.js?module). But when importing from a local file tree, most file servers will respond with a 404.

.d.ts files need not be fixed because TypeScript imports work differently. I also haven't fixed any files in the test folder as I assume these are intended to run in node and not be imported in the browser.