### PR TITLE
Add guard for unavailable `URLSearchParams`

### DIFF
--- a/src/RemoteDevTools/index.js
+++ b/src/RemoteDevTools/index.js
@@ -161,7 +161,7 @@ export function enableRemoteDevtools(remoteId) {
   );
 }
 
-if (hasWindow) {
+if (hasWindow && typeof URLSearchParams !== "undefined") {
   const urlParams = new URLSearchParams(window.location.search);
 
   // @todo Provide a way to disable it if needed


### PR DESCRIPTION
This adds a better guard for `URLSearchParams` eventually not being defined.

I ran into this when running the code in node (context: FastBoot, the Ember.js SSR solution, runs a client-side SPA in node, and has a `window` global defined - for whatever reason - but not any of the other browser APIs). But [IE also does not support `URLSearchParams`](https://caniuse.com/?search=URLSearchParams), so this is good to have in general I think!