### PR TITLE
Improve Component types to allow for type inference on schema properties

### DIFF
--- a/src/Component.d.ts
+++ b/src/Component.d.ts
@@ -10,21 +10,26 @@ export type ComponentSchema = {
 };
 
 // Base class for components,
-declare class BaseComponent<C> {
-  static schema: ComponentSchema;
-  static isComponent: true;
+export declare class ComponentClass<C> {
   copy(source: this): this;
   clone(): this;
   reset(): void;
   dispose(): void;
+  constructor(props?: Partial<C> | false);
 }
 
-type Component<T> = BaseComponent<T> & T;
+export type ComponentInstance<C> = ComponentClass<C> & C;
 
-export interface ComponentConstructor {
+interface ComponentStatic {
   schema: ComponentSchema;
   isComponent: true;
-  new <T>(props?: Partial<T> | false): Component<T>;
+  new <C>(props?: Partial<C> | false): ComponentInstance<C>;
 }
 
-export declare const Component: ComponentConstructor;
+export interface ComponentConstructor<C> {
+  schema: ComponentSchema;
+  isComponent: true;
+  new (props?: Partial<C> | false): ComponentInstance<C>;
+}
+
+export declare const Component: ComponentStatic;

--- a/src/Component.d.ts
+++ b/src/Component.d.ts
@@ -1,9 +1,5 @@
 import { PropType } from "./Types";
 
-/**
- * Base class for components.
- */
-
 export type ComponentSchemaProp = {
   default?: any;
   type: PropType<any, any>;
@@ -13,18 +9,22 @@ export type ComponentSchema = {
   [propName: string]: ComponentSchemaProp;
 };
 
-export class Component<C> {
+// Base class for components,
+declare class BaseComponent<C> {
   static schema: ComponentSchema;
   static isComponent: true;
-  constructor(props?: Partial<Omit<C, keyof Component<any>>> | false);
   copy(source: this): this;
   clone(): this;
   reset(): void;
   dispose(): void;
 }
 
-export interface ComponentConstructor<C extends Component<any>> {
+type Component<T> = BaseComponent<T> & T;
+
+export interface ComponentConstructor {
   schema: ComponentSchema;
   isComponent: true;
-  new (props?: Partial<Omit<C, keyof Component<any>>> | false): C;
+  new <T>(props?: Partial<T> | false): Component<T>;
 }
+
+export declare const Component: ComponentConstructor;

--- a/src/Entity.d.ts
+++ b/src/Entity.d.ts
@@ -1,4 +1,8 @@
-import { Component, ComponentConstructor } from "./Component";
+import {
+  ComponentConstructor,
+  ComponentInstance,
+  ComponentClass,
+} from "./Component";
 
 /**
  * An entity in the world.
@@ -19,49 +23,49 @@ export class Entity {
    * @param Component Type of component to get
    * @param includeRemoved Whether a component that is staled to be removed should be also considered
    */
-  getComponent<C extends Component<any>>(
+  getComponent<C>(
     Component: ComponentConstructor<C>,
     includeRemoved?: boolean
-  ): Readonly<C> | undefined;
+  ): Readonly<ComponentInstance<C>> | undefined;
 
   /**
    * Get a component that is slated to be removed from this entity.
    */
-  getRemovedComponent<C extends Component<any>>(
-      Component: ComponentConstructor<C>
-  ): Readonly<C> | undefined;
+  getRemovedComponent<C>(
+    Component: ComponentConstructor<C>
+  ): Readonly<ComponentInstance<C>> | undefined;
 
   /**
    * Get an object containing all the components on this entity, where the object keys are the component types.
    */
-  getComponents(): { [componentName: string]: Component<any> };
+  getComponents(): { [componentName: string]: ComponentInstance<any> };
 
   /**
    * Get an object containing all the components that are slated to be removed from this entity, where the object keys are the component types.
    */
-  getComponentsToRemove(): { [componentName: string]: Component<any> };
+  getComponentsToRemove(): { [componentName: string]: ComponentInstance<any> };
 
   /**
    * Get a list of component types that have been added to this entity.
    */
-  getComponentTypes(): Array<Component<any>>;
+  getComponentTypes(): Array<ComponentConstructor<any>>;
 
   /**
    * Get a mutable reference to a component on this entity.
    * @param Component Type of component to get
    */
-  getMutableComponent<C extends Component<any>>(
+  getMutableComponent<C extends any>(
     Component: ComponentConstructor<C>
-  ): C | undefined;
+  ): ComponentInstance<C> | undefined;
 
   /**
    * Add a component to the entity.
    * @param Component Type of component to add to this entity
    * @param values Optional values to replace the default attributes on the component
    */
-  addComponent<C extends Component<any>>(
+  addComponent<C extends any>(
     Component: ComponentConstructor<C>,
-    values?: Partial<Omit<C, keyof Component<any>>>
+    values?: Partial<Omit<C, keyof ComponentClass<C>>>
   ): this;
 
   /**
@@ -69,7 +73,7 @@ export class Entity {
    * @param Component Type of component to remove from this entity
    * @param forceImmediate Whether a component should be removed immediately
    */
-  removeComponent<C extends Component<any>>(
+  removeComponent<C extends any>(
     Component: ComponentConstructor<C>,
     forceImmediate?: boolean
   ): this;
@@ -79,7 +83,7 @@ export class Entity {
    * @param Component Type of component
    * @param includeRemoved Whether a component that is staled to be removed should be also considered
    */
-  hasComponent<C extends Component<any>>(
+  hasComponent<C extends any>(
     Component: ComponentConstructor<C>,
     includeRemoved?: boolean
   ): boolean;
@@ -88,7 +92,7 @@ export class Entity {
    * Check if the entity has a component that is slated to be removed.
    * @param Component Type of component
    */
-  hasRemovedComponent<C extends Component<any>>(
+  hasRemovedComponent<C extends any>(
     Component: ComponentConstructor<C>
   ): boolean;
 
@@ -96,37 +100,29 @@ export class Entity {
    * Check if the entity has all components in a list.
    * @param Components Component types to check
    */
-  hasAllComponents(
-    Components: Array<ComponentConstructor<any>>
-  ): boolean
+  hasAllComponents(Components: Array<ComponentConstructor<any>>): boolean;
 
   /**
    * Check if the entity has any of the components in a list.
    * @param Components Component types to check
    */
-  hasAnyComponents(
-    Components: Array<ComponentConstructor<any>>
-  ): boolean
+  hasAnyComponents(Components: Array<ComponentConstructor<any>>): boolean;
 
   /**
    * Remove all components on this entity.
    * @param forceImmediate Whether all components should be removed immediately
    */
-  removeAllComponents(
-      forceImmediate?: boolean
-  ): void
+  removeAllComponents(forceImmediate?: boolean): void;
 
-  copy(source: this): this
+  copy(source: this): this;
 
-  clone(): this
+  clone(): this;
 
-  reset(): void
+  reset(): void;
 
   /**
    * Remove this entity from the world.
    * @param forceImmediate Whether this entity should be removed immediately
    */
-  remove(
-      forceImmediate?: boolean
-  ): void;
+  remove(forceImmediate?: boolean): void;
 }

--- a/src/System.d.ts
+++ b/src/System.d.ts
@@ -1,4 +1,4 @@
-import {Component, ComponentConstructor} from "./Component";
+import { ComponentConstructor } from "./Component";
 import { Entity } from "./Entity";
 import { World } from "./World";
 
@@ -9,13 +9,13 @@ interface Attributes {
 
 export interface SystemQueries {
   [queryName: string]: {
-    components: (ComponentConstructor<any> | NotComponent<any>)[],
+    components: (ComponentConstructor<any> | NotComponent<any>)[];
     listen?: {
-      added?: boolean,
-      removed?: boolean,
-      changed?: boolean | ComponentConstructor<any>[],
-    },
-  }
+      added?: boolean;
+      removed?: boolean;
+      changed?: boolean | ComponentConstructor<any>[];
+    };
+  };
 }
 
 /**
@@ -38,12 +38,12 @@ export abstract class System<EntityType extends Entity = Entity> {
    */
   queries: {
     [queryName: string]: {
-      results: EntityType[],
-      added?: EntityType[],
-      removed?: EntityType[],
-      changed?: EntityType[],
-    }
-  }
+      results: EntityType[];
+      added?: EntityType[];
+      removed?: EntityType[];
+      changed?: EntityType[];
+    };
+  };
 
   world: World<EntityType>;
 
@@ -60,7 +60,7 @@ export abstract class System<EntityType extends Entity = Entity> {
   /**
    * Called when the system is added to the world.
    */
-  init(attributes?: Attributes): void
+  init(attributes?: Attributes): void;
 
   /**
    * Resume execution of this system.
@@ -83,16 +83,18 @@ export abstract class System<EntityType extends Entity = Entity> {
 
 export interface SystemConstructor<T extends System> {
   isSystem: true;
-  queries: SystemQueries
+  queries: SystemQueries;
   new (...args: any): T;
 }
 
-export interface NotComponent<C extends Component<any>> {
-  type: "not",
-  Component: ComponentConstructor<C>
+export interface NotComponent<C extends any> {
+  type: "not";
+  Component: ComponentConstructor<C>;
 }
 
 /**
  * Use the Not class to negate a component query.
  */
-export function Not<C extends Component<any>>(Component: ComponentConstructor<C>): NotComponent<C>;
+export function Not<C extends any>(
+  Component: ComponentConstructor<C>
+): NotComponent<C>;

--- a/src/SystemStateComponent.d.ts
+++ b/src/SystemStateComponent.d.ts
@@ -1,14 +1,15 @@
-import { Component, ComponentConstructor } from "./Component";
+import { ComponentConstructor, ComponentStatic } from "./Component";
 
 /**
  * Components that extend the SystemStateComponent are not removed when an entity is deleted.
  */
-export class SystemStateComponent<C> extends Component<C> {
-  static isSystemStateComponent: true;
-}
-
-export interface SystemStateComponentConstructor<C extends Component<any>> extends ComponentConstructor<C> {
+interface SystemStateComponentStatic extends ComponentStatic {
   isSystemStateComponent: true;
-  new (): C;
 }
 
+export interface SystemStateComponentConstructor<C>
+  extends ComponentConstructor<C> {
+  isSystemStateComponent: true;
+}
+
+export declare const SystemStateComponent: SystemStateComponentStatic;

--- a/src/TagComponent.d.ts
+++ b/src/TagComponent.d.ts
@@ -1,14 +1,20 @@
-import { Component, ComponentConstructor } from "./Component";
+import {
+  ComponentConstructor,
+  ComponentInstance,
+  ComponentStatic,
+} from "./Component";
 
 /**
  * Create components that extend TagComponent in order to take advantage of performance optimizations for components
  * that do not store data
  */
-export class TagComponent extends Component<{}> {
-  static isTagComponent: true;
+interface TagComponentStatic extends ComponentStatic {
+  isTagComponent: true;
+  new (): ComponentInstance<{}>;
 }
 
-export interface TagComponentConstructor<C extends Component<{}>> extends ComponentConstructor<C> {
+export interface TagComponentConstructor extends ComponentConstructor<{}> {
   isTagComponent: true;
-  new (): C;
 }
+
+export declare const TagComponent: TagComponentStatic;

--- a/src/World.d.ts
+++ b/src/World.d.ts
@@ -1,4 +1,4 @@
-import { Component, ComponentConstructor } from "./Component";
+import { ComponentConstructor } from "./Component";
 import { System, SystemConstructor } from "./System";
 import { Entity } from "./Entity";
 import { ObjectPool } from "./ObjectPool";
@@ -12,7 +12,6 @@ export interface WorldOptions {
  * The World is the root of the ECS.
  */
 export class World<EntityType extends Entity = Entity> {
-
   /**
    * Whether the world tick should execute.
    */
@@ -27,13 +26,18 @@ export class World<EntityType extends Entity = Entity> {
    * Register a component.
    * @param Component Type of component to register
    */
-  registerComponent<C extends Component<any>>(Component: ComponentConstructor<C>, objectPool?: ObjectPool<C> | false): this;
+  registerComponent<C extends any>(
+    Component: ComponentConstructor<C>,
+    objectPool?: ObjectPool<C> | false
+  ): this;
 
   /**
    * Evluate whether a component has been registered to this world or not.
    * @param Component Type of component to to evaluate
    */
-  hasRegisteredComponent<C extends Component<any>>(Component: ComponentConstructor<C>): boolean;
+  hasRegisteredComponent<C extends any>(
+    Component: ComponentConstructor<C>
+  ): boolean;
 
   /**
    * Register a system.
@@ -68,16 +72,15 @@ export class World<EntityType extends Entity = Entity> {
   /**
    * Resume execution of this world.
    */
-  play(): void
+  play(): void;
 
   /**
    * Stop execution of this world.
    */
-  stop(): void
+  stop(): void;
 
   /**
    * Create a new entity
    */
-  createEntity(name?: string): EntityType
-
+  createEntity(name?: string): EntityType;
 }

--- a/test/types/test.ts
+++ b/test/types/test.ts
@@ -1,0 +1,74 @@
+import { Component } from "../../src/Component";
+import { Entity } from "../../src/Entity";
+import { SystemStateComponent } from "../../src/SystemStateComponent";
+import { TagComponent } from "../../src/TagComponent";
+import { Types } from "../../src/Types";
+import { World } from "../../src/World";
+
+// COMPONENT
+class Position extends Component<{ x: number; y: number }> {}
+Position.isComponent;
+Position.schema = {
+  x: { type: Types.Number },
+  y: { type: Types.Number },
+};
+
+const position = new Position();
+position.x;
+position.y;
+
+const position2 = new Position({ x: 5, y: 9 });
+position2.clone();
+
+// TAG COMPONENT
+class TestTagComponent extends TagComponent {}
+TestTagComponent.isTagComponent;
+
+const testTagComponent = new TestTagComponent();
+TestTagComponent.isComponent;
+testTagComponent.clone();
+
+// SYSTEM STATE COMPONENT
+class SystemComponent extends SystemStateComponent<{ foo: boolean }> {}
+SystemComponent.isComponent;
+SystemComponent.isSystemStateComponent;
+
+SystemComponent.schema = {
+  foo: { type: Types.Boolean },
+};
+
+const sComponent = new SystemComponent({ foo: true });
+sComponent.foo;
+sComponent.clone();
+
+// WORLD
+const world = new World();
+world.registerComponent(Position);
+world.hasRegisteredComponent(Position);
+
+// ENTITY
+
+const entity = new Entity();
+
+entity.addComponent(Position);
+
+const entityPosition = entity.getComponent(Position, true);
+entityPosition?.x;
+
+entity.hasAllComponents([Position]);
+entity.hasAnyComponents([Position]);
+entity.hasComponent(Position);
+entity.hasRemovedComponent(Position);
+
+entity.removeComponent(Position);
+const removedEntityPosition = entity.getRemovedComponent(Position);
+const allComponentsToRemove = entity.getComponentsToRemove();
+
+const allComponents = entity.getComponents();
+const allComponentTyes = entity.getComponentTypes();
+
+const entityMutablePosition = entity.getMutableComponent(Position);
+entityMutablePosition.x = 54;
+
+entity.removeAllComponents();
+entity.clone();


### PR DESCRIPTION
These changes should enable type inference on component schema properties, while not changing the way Components are constructed. 

Now when using Typescript and creating a component like: `class Position extends Component<{ x: number, y: number }>{}` for any new instance of `Position` typescript will recognize all base `Component` properties, as well as the properties specified in the Component generic type parameter (the schema). (in this case, `new Position().x` will resolve to `number`)

[Example usage (type declarations copied from PR)](https://www.typescriptlang.org/play?#code/PQ4AgZQFwVwIwM5gGYCcD2BbM6oAsBTVMKATwAcCEAoMysABQ3IBUKCAeFgGjAFUAfGAC8YAIYA7UgG5q1AhJjY2lJAG9qYMADklcItQC+1UOACiEgCaRYiOabAtCYSwQDGAGzGoxUAJboEih+HgRgABQAwgDyDACSZgAiYABiAErRALKMaQCU8gAe5OioUCTsYJFYxRIKUBBuhJhiTOjkImAaWq7IYjAeUAD8AFziUrJadASjrazsHJKkvIsCsoayhcWl5fRVmDV1DU1iHV1gANrkzNpimNNgCFCofhIA5gC6o3sHEvWNBM1ZmsNiAwAAhMQIMKeSFIZAlMBuaqBOoIbjUVww1DQrwIJAQqHfFG-DiRIRnR6+PxuB7-ZpfZG1X5HAFiCYPKBUml+BBEplQUZPGAEdlI8ikcIIdAwVBue74Hm5QV4Hmijwo8JKkgqhDs7FQqCa0YAN3Qfks7MsPOKUKNYFN5rWcimlUZdS4QlEBIIfPdLCEADJHBsCEUSmUXlAiL05a79sSoFUJI9UDA3FAERS6WIGfH+Szmuyeb7foLUyLNGBagB3MAe8JXNoIEaMbz+MQeD1gAA+KA7UK1JagHqdm3DLncXmxiMCjzjPwF84TSZTaYzqFkDgs1kxU6pgWCoXsoEcVDKMAQYleBBM4BYZggLC+2KpbyX-N4UceL1eYFDTxOBBszARtKFKPwqGoGE8UYdAED8fwD3-BRLCQIcODUMAClGRRMH0VBeFIHC9CIMBDAENRjGoBg4IQgIJAAOiA45TjAUFoC5EDmCIfwqDAasSgAa0rbDOh2e4VCoBjdDw0jDHRLQiLEqZRkkhBpJI1BjCopFkzKG06IPUQa1g+DEIkTVZAM8yGIKaQ2PMAoANpFjQJ4iCkAE1BhOs+iGJkahfMCBixRkBzwUhaE3V+Li2ncvivOE29HAfJ9XT01N0wRbxXiUVEoNnfTaPMgAmDoTJosz6PCTDRIARkI0YABYyNyEE71S0Y0gIZAiAUNwf1isDeLhDBsCmXgJFwMAXkpCQ5VoCoAA1JI6dC1FE3D8MaqtNLIgRzgAIgKQ73lkF0qnFVbRHWzbNJ2ra5IOw7QtO6QgA)

Fixes #249 