### PR TITLE
Add default generic type for Component<C>

### DIFF
--- a/src/Component.d.ts
+++ b/src/Component.d.ts
@@ -13,7 +13,7 @@ export type ComponentSchema = {
   [propName: string]: ComponentSchemaProp;
 };
 
-export class Component<C> {
+export class Component<C = {}> {
   static schema: ComponentSchema;
   static isComponent: true;
   constructor(props?: Partial<Omit<C, keyof Component<any>>> | false);


### PR DESCRIPTION
This generic is redundant since `props` are optional.

---
> [Out of Topic] Just curious, why not make ComponentSchema be generic instead of props?