### PR TITLE
Added optional mandatory field to the `SystemQueries` interface

### DIFF
--- a/src/System.d.ts
+++ b/src/System.d.ts
@@ -15,6 +15,7 @@ export interface SystemQueries {
       removed?: boolean,
       changed?: boolean | ComponentConstructor<any>[],
     },
+    mandatory?: boolean,
   }
 }
 


### PR DESCRIPTION
Currently, there is an option to mark a query as mandatory for a System, however if you try to add this field while using TypeScript, you will get an error since that field is not present on the `SystemQueries` interface.

This PR is to address https://github.com/ecsyjs/ecsy/issues/272.