### PR TITLE
Expose EntityManager getEntityByName in World

### DIFF
--- a/src/World.d.ts
+++ b/src/World.d.ts
@@ -80,4 +80,9 @@ export class World<EntityType extends Entity = Entity> {
    */
   createEntity(name?: string): EntityType
 
+  /**
+   * Get an entity registered in this world by name.
+   */
+  getEntityByName(name?: string): EntityType
+
 }

--- a/src/World.js
+++ b/src/World.js
@@ -84,6 +84,10 @@ export class World {
     return this.entityManager.createEntity(name);
   }
 
+  getEntityByName(name) {
+    return this.entityManager.getEntityByName(name);
+  }
+
   stats() {
     var stats = {
       entities: this.entityManager.stats(),


### PR DESCRIPTION
There is a built-in entity manager but we are unable to benefit from this and retrieve entities by name from the world object. This pull request changes that. I expose getEntityByName from EntityManager.js in World.js. Resolves #226 
