### PR TITLE
Optional System.execute()

### DIFF
--- a/src/System.d.ts
+++ b/src/System.d.ts
@@ -78,7 +78,7 @@ export abstract class System<EntityType extends Entity = Entity> {
    * @param delta
    * @param time
    */
-  abstract execute(delta: number, time: number): void;
+  execute(delta: number, time: number): void;
 }
 
 export interface SystemConstructor<T extends System> {


### PR DESCRIPTION
The framework is designed to handle systems without an execute function, and systems can be written purely for handling initialization. Therefore the execute function should not be marked absract.