### PR TITLE
Fix threejs example `moving` schema.

### DIFF
--- a/site/examples/ball-example/three/components.mjs
+++ b/site/examples/ball-example/three/components.mjs
@@ -3,7 +3,12 @@ import { TagComponent, Component, Types } from "../../../build/ecsy.module.js";
 export class Collidable extends TagComponent {}
 export class Collider extends TagComponent {}
 export class Recovering extends TagComponent {}
+
 export class Moving extends TagComponent {}
+
+Moving.schema = {
+  offset: { type: Types.Number, default: 0 }
+};
 
 export class PulsatingScale extends Component {}
 


### PR DESCRIPTION
Fix warning:
"Trying to set attribute 'offset' not defined in the 'Moving' schema. Please fix the schema, the attribute value won't be set"